### PR TITLE
Delivery report

### DIFF
--- a/src/Traits/Sms/HandlesSms.php
+++ b/src/Traits/Sms/HandlesSms.php
@@ -173,4 +173,21 @@ trait HandlesSms
             'DELETE'
         );
     }
+
+    /**
+     * @param string $destAddr
+     * 
+     * @param string $requestId
+     *
+     * @return Response
+     *
+     * @throws ConfigurationUnavailableException
+     */
+    public function smsDeliveryReport(string $destAddr, string $requestId): Response
+    {
+        return $this->call(
+            "https://dlrapi.beem.africa/public/v1/delivery-reports?dest_addr=$destAddr&request_id=$requestId",
+            'GET'
+        );
+    }
 }

--- a/src/Traits/Sms/HandlesSms.php
+++ b/src/Traits/Sms/HandlesSms.php
@@ -175,6 +175,7 @@ trait HandlesSms
     }
 
     /**
+     * Delivery reports for sms can be accessed by requesting the status of each message using the below request. Delivery status should be checked 5mins or later after an sms has been submitted to the platform to allow for any delivery delays experienced with mobile network operators.
      * @param string $destAddr
      * 
      * @param string $requestId

--- a/tests/Feature/SmsTest.php
+++ b/tests/Feature/SmsTest.php
@@ -53,4 +53,16 @@ class SmsTest extends TestCase
 
         $this->assertTrue($request->successful());
     }
+
+    /** @test */
+    public function it_can_check_delivery_report()
+    {
+        $request = Beem::sms(
+            'Your verification code: 34990',
+            [['recipient_id' => (string) now()->timestamp, 'dest_addr' => '255753820520']]
+        );
+        sleep(60 * 10);
+        $request2 = Beem::smsDeliveryReport('255753820520', json_decode($request,true)['request_id']);
+        $this->assertTrue((json_decode($request2,true)['dest_addr']=='255753820520'));
+    }
 }


### PR DESCRIPTION
Delivery reports for sms can be accessed by requesting the status of each message using the below request. Delivery status should be checked 5mins or later after an sms has been submitted to the platform to allow for any delivery delays experienced with mobile network operators.